### PR TITLE
Use dcb default context on axon server via compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,17 +23,8 @@ To run the app with Axon Server, you need to have an instance of Axon Server run
 docker compose up
 ```
 
-#### Axon Server Context
-
-Then you need to open the Axon Server UI at [http://localhost:8024](http://localhost:8024) and create a new context named `university`.
-What is essential, you need also check the `DCB context (beta)` checkbox in the `General` settings tab.
-![AxonServer_DCBContext_Creation.png](docs/images/AxonServer_DCBContext_Creation.png)
-
-If you did not create the context, the command execution will fail with the following error:
-```
-org.axonframework.commandhandling.CommandExecutionException: Exception while handling command
-Caused by: java.util.concurrent.ExecutionException: io.grpc.StatusRuntimeException: UNAVAILABLE
-```
+This `docker-compose.yaml` file uses the latest official Axon Server Docker image configured to use the `default` context 
+with dynamic consistency boundary enabled.
 
 #### The app configuration
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,13 +1,14 @@
 services:
   axon-server:
-    image: docker.axoniq.io/axoniq/axonserver:2025.2.0
+    image: axoniq/axonserver:2025.2.0
+    hostname: axon-server
     ports:
       - "8024:8024"
       - "8124:8124"
     environment:
-      axoniq_axonserver_hostname: axon-server
-      axoniq_axonserver_autocluster_first: axon-server
-      axoniq_axonserver_autocluster_contexts: _admin
+      AXONIQ_AXONSERVER_HOSTNAME: axon-server
+      AXONIQ_AXONSERVER_STANDALONE_DCB: true
+      AXONIQ_AXONSERVER_DEVMODE_ENABLED: true
     volumes:
       - data:/axonserver/data
       - events:/axonserver/events

--- a/src/main/java/io/axoniq/demo/university/UniversityAxonApplication.java
+++ b/src/main/java/io/axoniq/demo/university/UniversityAxonApplication.java
@@ -20,7 +20,7 @@ import java.util.logging.Logger;
 
 public class UniversityAxonApplication {
 
-    private static final String CONTEXT = "university";
+    private static final String CONTEXT = "default";
     private static final Logger logger = Logger.getLogger(UniversityAxonApplication.class.getName());
 
     public static void main(String[] args) {


### PR DESCRIPTION
To run the demo, using `AXONIQ_AXONSERVER_STANDALONE_DCB=true`, it is no longer required to manually configure a DBC context, we can just start the docker compose.

Also: adjust readme, update config